### PR TITLE
Update "should site-key anyway" checks to track the BCG

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,28 +116,18 @@ In particular, when creating a document, we use the following in place of the cu
 1. If _key_ is an [origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin), then return _origin_.
 1. If _group_'s [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map)\[_origin_] exists, then return _origin_.
 1. If _requestsIsolation_ is true:
-    1. If _group_'s [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map)\[_site_] exists, and _group_'s [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map)\[_site_] has seen _origin_ before, then return _site_.
+    1. If _group_'s [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map)\[_site_] exists, and _group_ has seen _origin_ before, then return _site_.
     1. Return _origin_.
 1. Return _site_.
 
-A browsing context agent cluster _agentCluster_ **has seen an origin before**, given an origin _origin_, if the following algorithm returns true:
-
-1. Let _windowAgent_ be the single [similar-origin window agent](https://html.spec.whatwg.org/#similar-origin-window-agent) in _agentCluster_.
-1. For each [realm](https://tc39.es/ecma262/#sec-code-realms) _realm_ whose agent is _windowAgent_:
-    1. Let _window_ be _realm_'s [global object](https://html.spec.whatwg.org/#concept-realm-global).
-    1. Assert: _window_ is a `Window` object.
-    1. Let _browsingContext_ be _window_'s [browsing context](https://html.spec.whatwg.org/#window-bc).
-    1. If _browsingContext_ is null, then continue.
-    1. Let _sessionHistory_ be _browsingContext_'s [session history](https://html.spec.whatwg.org/#session-history).
-    1. If _sessionHistory_ contains an [entry](https://html.spec.whatwg.org/#session-history-entry) whose `Document` is non-null, and that `Document`'s [origin](https://dom.spec.whatwg.org/#concept-document-origin) is [same-origin](https://html.spec.whatwg.org/#same-origin) with _origin_, then return true.
-1. Return false.
+A browsing context group **has seen an origin before** if any of the browsing contexts in the group have at some point contained realms whose global object's associated `Document`'s origin matches the origin in question. (This will be formalized in the actual specification by tracking a list per BCG. Note that iframes that get removed from the document are no longer in the group, so do not contribute to this calculation.)
 
 This algorithm has two interesting features:
 
 * Even if origin isolation is not requested for a particular document creation, if origin isolation has previously created an origin-keyed agent cluster, then we put the new document in that origin-keyed agent cluster.
-* Even when origin isolation is requested, if there is a site-keyed agent cluster with same-origin documents in its session history, then we put the new document in that site-keyed agent cluster, ignoring the isolation request.
+* Even when origin isolation is requested, if there is a site-keyed agent cluster with same-origin documents in the browsing context group, then we put the new document in that site-keyed agent cluster, ignoring the isolation request.
 
-Both of these are consequences of a desire to ensure that same-origin sites do not end up isolated from each other, even in scenarios involving session history navigation and the back–forward cache.
+Both of these are consequences of a desire to ensure that same-origin sites do not end up isolated from each other, even in scenarios involving navigating through the session history.
 
 You can see a more full analysis of what results this algorithm produces in our [scenarios document](./scenarios.md).
 

--- a/README.md
+++ b/README.md
@@ -110,24 +110,16 @@ Moving to origin isolation requires some observable changes, and thus the opt-in
 
 The specification for this feature in itself consists of two parts. One part is header parsing, which relies on the [Structured Headers](https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html) specification to do most of the work. The other is agent cluster keying, which is done by modifying the HTML Standard's [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map).
 
-In particular, when creating a document, we use the following in place of the current algorithm for [obtain an agent cluster key](https://html.spec.whatwg.org/#obtain-agent-cluster-key). It takes as input an _origin_ of the realm to be created, _requestsIsolation_ (a boolean, derived from the presence of a valid `Origin-Isolation` header), and a browsing context group _group_. It outputs the [agent cluster key](https://html.spec.whatwg.org/#agent-cluster-key) to be used, which will be either a site or an origin.
+In particular, when creating a document, we modify the algorithm to [obtain an agent cluster key](https://html.spec.whatwg.org/#obtain-agent-cluster-key). It takes as input an _origin_ of the realm to be created, _requestsIsolation_ (a boolean, derived from the presence of a valid `Origin-Isolation` header), and a browsing context group _group_. It outputs the [agent cluster key](https://html.spec.whatwg.org/#agent-cluster-key) to be used, which will be either a site or an origin.
 
-1. Let _key_ be the result of [obtaining a site](https://html.spec.whatwg.org/multipage/webappapis.html#obtain-a-site) from _origin_.
-1. If _key_ is an [origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin), then return _origin_.
-1. If _group_'s [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map)\[_origin_] exists, then return _origin_.
-1. If _requestsIsolation_ is true:
-    1. If _group_'s [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map)\[_site_] exists, and _group_ has seen _origin_ before, then return _site_.
-    1. Return _origin_.
-1. Return _site_.
+The new algorithm will check if _origin_ has previously been placed in a site- or origin-keyed agent cluster within _group_, and if so, it will always return that same key, to stay consistent. Otherwise, it uses the _requestsIsolation_ boolean to determine whether to return _origin_, or the derived site.
 
-A browsing context group **has seen an origin before** if any of the browsing contexts in the group have at some point contained realms whose global object's associated `Document`'s origin matches the origin in question. (This will be formalized in the actual specification by tracking a list per BCG. Note that iframes that get removed from the document are no longer in the group, so do not contribute to this calculation.)
-
-This algorithm has two interesting features:
+The consistency part of this algorithm has two interesting features:
 
 * Even if origin isolation is not requested for a particular document creation, if origin isolation has previously created an origin-keyed agent cluster, then we put the new document in that origin-keyed agent cluster.
-* Even when origin isolation is requested, if there is a site-keyed agent cluster with same-origin documents in the browsing context group, then we put the new document in that site-keyed agent cluster, ignoring the isolation request.
+* Even when origin isolation is requested, if there has previously been a site-keyed agent cluster with same-origin documents in the browsing context group, then we put the new document in that site-keyed agent cluster, ignoring the isolation request.
 
-Both of these are consequences of a desire to ensure that same-origin sites do not end up isolated from each other, even in scenarios involving navigating through the session history.
+Both of these are consequences of a desire to ensure that same-origin sites do not end up isolated from each other, even in scenarios involving navigating back and forward.
 
 You can see a more full analysis of what results this algorithm produces in our [scenarios document](./scenarios.md).
 

--- a/README.md
+++ b/README.md
@@ -116,16 +116,28 @@ In particular, when creating a document, we use the following in place of the cu
 1. If _key_ is an [origin](https://html.spec.whatwg.org/multipage/origin.html#concept-origin), then return _origin_.
 1. If _group_'s [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map)\[_origin_] exists, then return _origin_.
 1. If _requestsIsolation_ is true:
-    1. If _group_'s [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map)\[_site_] exists, and _group_'s [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map)\[_site_] contains any agents which contain any realms whose [settings object](https://html.spec.whatwg.org/#concept-realm-settings-object)'s [origin](https://html.spec.whatwg.org/#concept-settings-object-origin) are [same-origin](https://html.spec.whatwg.org/#same-origin) with _origin_, then return _site_.
+    1. If _group_'s [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map)\[_site_] exists, and _group_'s [agent cluster map](https://html.spec.whatwg.org/#agent-cluster-map)\[_site_] has seen _origin_ before, then return _site_.
     1. Return _origin_.
 1. Return _site_.
+
+A browsing context agent cluster _agentCluster_ **has seen an origin before**, given an origin _origin_, if the following algorithm returns true:
+
+1. Let _windowAgent_ be the single [similar-origin window agent](https://html.spec.whatwg.org/#similar-origin-window-agent) in _agentCluster_.
+1. For each [realm](https://tc39.es/ecma262/#sec-code-realms) _realm_ whose agent is _windowAgent_:
+    1. Let _window_ be _realm_'s [global object](https://html.spec.whatwg.org/#concept-realm-global).
+    1. Assert: _window_ is a `Window` object.
+    1. Let _browsingContext_ be _window_'s [browsing context](https://html.spec.whatwg.org/#window-bc).
+    1. If _browsingContext_ is null, then continue.
+    1. Let _sessionHistory_ be _browsingContext_'s [session history](https://html.spec.whatwg.org/#session-history).
+    1. If _sessionHistory_ contains an [entry](https://html.spec.whatwg.org/#session-history-entry) whose `Document` is non-null, and that `Document`'s [origin](https://dom.spec.whatwg.org/#concept-document-origin) is [same-origin](https://html.spec.whatwg.org/#same-origin) with _origin_, then return true.
+1. Return false.
 
 This algorithm has two interesting features:
 
 * Even if origin isolation is not requested for a particular document creation, if origin isolation has previously created an origin-keyed agent cluster, then we put the new document in that origin-keyed agent cluster.
-* Even when origin isolation is requested, if there is a site-keyed agent cluster with same-origin documents, then we put the new document in that site-keyed agent cluster, ignoring the isolation request.
+* Even when origin isolation is requested, if there is a site-keyed agent cluster with same-origin documents in its session history, then we put the new document in that site-keyed agent cluster, ignoring the isolation request.
 
-Both of these are consequences of a desire to ensure that same-origin sites do not end up isolated from each other.
+Both of these are consequences of a desire to ensure that same-origin sites do not end up isolated from each other, even in scenarios involving session history navigation and the back–forward cache.
 
 You can see a more full analysis of what results this algorithm produces in our [scenarios document](./scenarios.md).
 

--- a/scenarios.md
+++ b/scenarios.md
@@ -50,11 +50,7 @@ The user then clicks a button in the main frame which inserts a second subframe,
 * Subframe 1: `https://e.org` (with `https://x.e.com` in the session history)
 * Subframe 2: `https://x.e.com` w/ OI
 
-The outcome for subframe 2 depends now on whether the `https://x.e.com` document in session history was retained in the back–forward cache. (I.e., whether the relevant session history entry contains a non-null `Document`.)
-
-If it was retained, then subframe 2 ends up keyed by `Site{https://e.com}`. This ensures that if the user navigates subframe 1 back, restoring the `Site{https://e.com}`-keyed instance of `https://x.e.com` in subframe 1, that subframe 1 and subframe 2 are still in the same `Site{https://e.com}` agent cluster, i.e. we have avoided isolating same-origin pages from each other.
-
-If it was not retained, then subframe 2 ends up keyed by `Origin{https://x.e.com}`, as there is nothing keyed by `Site{https://e.com}` in the agent cluster map. Then, if the user navigates subframe 2 back, since there is no back–forward cache document stored for `https://x.e.com`, a new one will be created. This new one will go through the process of choosing an agent cluster key, and also end up with `Origin{https://x.e.com}`. So again, we have ensured that subframe 1 and subframe 2 are both in the same agent cluster (this time the `Origin{https://x.e.com}` one), and have avoided isolating same-origin pages from each other. And even better, this time we were able to respect the origin isolation request, since there was nothing in the back–forward cache to prevent us.
+In this case, subframe 2 ends up keyed by `Site{https://e.com}`. This ensures that if the user navigates subframe 1 back, restoring the `Site{https://e.com}`-keyed instance of `https://x.e.com` in subframe 1, that subframe 1 and subframe 2 are still in the same `Site{https://e.com}` agent cluster, i.e. we have avoided isolating same-origin pages from each other.
 
 ### Inserting iframes and saving JS references
 
@@ -79,7 +75,7 @@ Some time later, JavaScript code inserts a new subframe, again pointing at `http
 
 Will the subframe get site-keyed, or origin-keyed?
 
-The answer is origin-keyed. The `window.savedFrame` variable does mean that the agent cluster map still contains an entry with key `Site{https://e.org}`, which itself contains the saved realm and corresponding `Window` object. However, because the iframe was removed from the DOM, the `Window` has  no browsing context, and thus no session history. This means there is no session history containing an `https://e.org`-origin `Document` within the agent cluster. Thus the request for origin isolation is respected, and we end up with `Origin{https://example.org/}` as the key.
+The answer is origin-keyed. The `window.savedFrame` variable does mean that the agent cluster map still contains an entry with key `Site{https://e.org}`, which itself contains the saved realm and corresponding `Window` object. However, because the iframe was removed from the DOM, the `Window` has no browsing context, and thus the browsing context group does not contain any browsing contexts that have seen the `https://e.org` origin. Thus the request for origin isolation is respected, and we end up with `Origin{https://example.org/}` as the key.
 
 
 ## Worked-out nested scenario


### PR DESCRIPTION
Closes #8.

/cc @annevk @wjmaclean

(I'll probably move this spec text into https://wicg.github.io/origin-policy/ soon, but for now it's here.)

I decided to check the session history entry's Document's origin, if the Document exists, instead of checking the session history entry's URL. As the "navigating a subframe" scenario illustrates, this allows better isolation when bfcache eviction happens. I'm open to being convinced this was the wrong tradeoff, but I thought since there were already some racy scenarios, it probably was OK.